### PR TITLE
Update to the DB schema to support chains of trust

### DIFF
--- a/modules/postgresmodule/schema.sql
+++ b/modules/postgresmodule/schema.sql
@@ -51,6 +51,7 @@ CREATE TABLE scans  (
 	replay 				        integer NULL,
 	has_tls						bool NOT NULL,
 	cert_id		              	integer references certificates(id) NOT NULL,
+    trust_id                    integer references trust(id) NOT NULL,
 	is_valid                   	bool NULL,
 	completion_perc				integer NULL,
 	validation_error           	varchar NULL,

--- a/modules/postgresmodule/schema.sql
+++ b/modules/postgresmodule/schema.sql
@@ -1,27 +1,3 @@
-CREATE TABLE scans  (
-	id                         	serial primary key,
-	time_stamp	           		timestamp NOT NULL,
-	target						varchar NOT NULL,
-	replay 				        integer NULL,
-	has_tls						bool NOT NULL,
-	cert_id		              	integer references certificates(id),
-	is_valid                   	bool NULL,
-	completion_perc				integer NULL,
-	validation_error           	varchar NULL,
-	is_ubuntu_valid           	bool NULL,
-	is_mozilla_valid           	bool NULL,
-	is_windows_valid           	bool NULL,
-	is_apple_valid             	bool NULL,
-	conn_info                	jsonb NULL
-);
-
-CREATE TABLE worker_output  (
-	id                         	serial primary key,
-	scan_id		              	varchar references scans(id),
-	worker_name	           		varchar NOT NULL,
-	output						jsonb NULL
-);
-
 CREATE TABLE certificates  (
 	id                         	serial primary key,
 	sha1_fingerprint           	varchar NOT NULL,
@@ -46,7 +22,6 @@ CREATE TABLE certificates  (
 	x509_subjectAltName        	varchar NULL,
 	x509_issuerAltName         	varchar NULL,
 	signature_algo             	varchar NULL,
-	parent_id					numeric NULL,
 	in_openssl_root_store      	bool NULL,
 	in_mozilla_root_store      	bool NULL,
 	in_windows_root_store      	bool NULL,
@@ -54,4 +29,37 @@ CREATE TABLE certificates  (
 	is_revoked                 	bool NULL,
 	revoked_at                 	timestamp NULL,
 	raw_cert					varchar NOT NULL
+);
+
+CREATE TABLE trust (
+    id                          serial primary key,
+    cert_id                     integer references certificates(id) NOT NULL,
+    issuer_id                   integer references certificates(id) NOT NULL,
+    timestamp                   timestamp NOT NULL,
+	trusted_ubuntu           	bool NULL,
+	trusted_mozilla           	bool NULL,
+	trusted_microsoft           bool NULL,
+	trusted_apple             	bool NULL,
+    trusted_android             bool NULL,
+    is_current                  bool NOT NULL
+);
+
+CREATE TABLE scans  (
+	id                         	serial primary key,
+	time_stamp	           		timestamp NOT NULL,
+	target						varchar NOT NULL,
+	replay 				        integer NULL,
+	has_tls						bool NOT NULL,
+	cert_id		              	integer references certificates(id) NOT NULL,
+	is_valid                   	bool NULL,
+	completion_perc				integer NULL,
+	validation_error           	varchar NULL,
+	conn_info                	jsonb NULL
+);
+
+CREATE TABLE analysis  (
+	id                         	serial primary key,
+	scan_id		              	integer references scans(id),
+	worker_name	           		varchar NOT NULL,
+	output						jsonb NULL
 );


### PR DESCRIPTION
This schema should support multiple chain of trusts per certificate, as well as updating the status of a chain of trust over time.
![schema](http://i.imgur.com/P142Aoc.png)

r? @0xDiBa @marumari